### PR TITLE
Better image tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: terraform apply
           command: |
-            terraform -chdir=./terraform apply -input=false -auto-approve plan.out
+            terraform -chdir=./terraform apply -auto-approve plan.out
       - persist_to_workspace:
           root: .
           paths:
@@ -102,16 +102,16 @@ workflows:
             - terraform/validate
       - hold:
           type: approval
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
           requires:
             - terraform-plan
             - build
       - terraform-apply:
           context: aws
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
           requires:
             - hold


### PR DESCRIPTION
Use SHA1 hash of commit to make unique images for each push allowing ability to revert easily if needed.